### PR TITLE
Docs/javadoc and swagger documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ ext {
     ktLoggingVersion = "3.0.5"
     mockkVersion = "1.13.5"
     kotlinxCoroutineTestVersion = "1.7.3"
+    springdoc = "2.6.0"
 }
 
 dependencies {
@@ -40,6 +41,8 @@ dependencies {
     implementation ("org.flywaydb:flyway-core:$flywayVersion")
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation ("io.github.microutils:kotlin-logging-jvm:$ktLoggingVersion")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdoc")
+
 
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/BulkCreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/BulkCreateControllerCoroutine.kt
@@ -1,21 +1,75 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
 import the.coding.force.exploring_kotlin_coroutines.request.BulkCreateDataRequest
 import the.coding.force.exploring_kotlin_coroutines.service.coroutine.BulkCreateDataServiceCoroutine
+import io.swagger.v3.oas.annotations.parameters.RequestBody as RequestBodySwagger
 
 @RestController
 @RequestMapping("/api/coroutine")
+@Tag(
+    name = "load test endpoints",
+    description = "these endpoints are about load test to save several data in database"
+)
 class BulkCreateControllerCoroutine(
     private val bulkCreateDataService: BulkCreateDataServiceCoroutine
 ) {
+    @Operation(
+        summary = "create several data in database on coroutine context",
+        description = "received a `BulkCreateDataRequest` that contains the quantity of data to save in database and the status"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exceṕtion", 
+                            "path": "/api/coroutine/create"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @PostMapping("/bulk/create")
-    suspend fun create(@RequestBody request: BulkCreateDataRequest): ResponseEntity<Unit> {
+    suspend fun create(
+        @RequestBodySwagger(
+            description = "DTO (data transfer object) used to save a new entity in database",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = BulkCreateDataRequest::class),
+                )
+            ]
+        )
+        @RequestBody request: BulkCreateDataRequest
+    ): ResponseEntity<Unit> {
         bulkCreateDataService.create(request.quantity, request.toDto())
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/BulkCreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/BulkCreateControllerCoroutine.kt
@@ -29,7 +29,7 @@ class BulkCreateControllerCoroutine(
 ) {
     @Operation(
         summary = "create several data in database on coroutine context",
-        description = "received a `BulkCreateDataRequest` that contains the quantity of data to save in database and the status"
+        description = "receives a `BulkCreateDataRequest` that contains the quantity of data to save in database and the status"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
@@ -26,7 +26,7 @@ class CreateControllerCoroutine(
 ) {
     @Operation(
         summary = "create a DataEntity",
-        description = "received a `CreateDataRequest` as body and convert to DTO to save in database",
+        description = "receives a `CreateDataRequest` as body and convert to DTO to save in database",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
@@ -1,21 +1,73 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
 import the.coding.force.exploring_kotlin_coroutines.request.CreateDataRequest
 import the.coding.force.exploring_kotlin_coroutines.service.coroutine.CreateDataServiceCoroutine
+import io.swagger.v3.oas.annotations.parameters.RequestBody as RequestBodySwagger
 
 @RestController
 @RequestMapping("/api/coroutine")
+@Tag(name = "coroutine", description = "operations in a coroutine context")
 class CreateControllerCoroutine(
     private val createDataService: CreateDataServiceCoroutine
 ) {
+    @Operation(
+        summary = "create a DataEntity",
+        description = "received a `CreateDataRequest` as body and convert to DTO to save in database",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                        "timestamp": "2023-12-06T12:34:56",
+                        "status": 500,
+                        "error": "Internal Server Error",
+                        "message": "Unexpected error occurred.",
+                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                        "path": "/api/coroutine/create"
+                    }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @PostMapping("/create")
-    suspend fun create(@RequestBody request: CreateDataRequest): ResponseEntity<Unit> {
+    suspend fun create(
+        // renamed the requestBody reference from swagger to prevent conflicts of the same name
+        @RequestBodySwagger(
+            description = "DTO (data transfer object) used to save a new entity in database",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = CreateDataRequest::class),
+                )
+            ]
+        )
+        @RequestBody request: CreateDataRequest
+    ): ResponseEntity<Unit> {
         createDataService.create(request.toDto())
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
@@ -40,13 +40,13 @@ class CreateControllerCoroutine(
                     examples = [
                         ExampleObject(
                             value = """{
-                        "timestamp": "2023-12-06T12:34:56",
-                        "status": 500,
-                        "error": "Internal Server Error",
-                        "message": "Unexpected error occurred.",
-                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                        "path": "/api/coroutine/create"
-                    }"""
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exceṕtion", 
+                            "path": "/api/coroutine/create"
+                           }"""
                         )
                     ]
                 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
@@ -1,20 +1,68 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.service.coroutine.DeleteDataServiceCoroutine
 
 @RestController
 @RequestMapping("/api/coroutine")
+@Tag(name = "coroutine", description = "operations in coroutine context")
 class DeleteControllerCoroutine(
     private val deleteDataService: DeleteDataServiceCoroutine
 ) {
 
+    @Operation(
+        summary = "delete a entity",
+        description = "received a `dataId` as pathVariable and try to remove the data in database"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "404",
+            description = "not found",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                        "status": 404,
+                        "error": "NOT_FOUND",
+                        "message": "Data with ID x was not found for deletion",
+                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                        "path": "/api/coroutine/delete/10"
+                    }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @DeleteMapping("delete/{id}")
-    suspend fun delete(@PathVariable("id") dataId: Long): ResponseEntity<Unit> {
+    suspend fun delete(
+        @Parameter(
+            name = "id",
+            description = "Unique identifier of the data to delete in the database",
+            required = true,
+            example = "10",
+            schema = Schema(type = "long", format = "int64", minimum = "1")
+        )
+        @PathVariable("id") dataId: Long
+    ): ResponseEntity<Unit> {
         deleteDataService.delete(dataId)
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
@@ -39,13 +39,13 @@ class DeleteControllerCoroutine(
                     examples = [
                         ExampleObject(
                             value = """{
-                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
-                        "status": 404,
-                        "error": "NOT_FOUND",
-                        "message": "Data with ID x was not found for deletion",
-                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                        "path": "/api/coroutine/delete/10"
-                    }"""
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 404,
+                            "error": "NOT_FOUND",
+                            "message": "Data with ID x was not found for deletion",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                            "path": "/api/coroutine/delete/10"
+                           }"""
                         )
                     ]
                 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
@@ -25,7 +25,7 @@ class DeleteControllerCoroutine(
 
     @Operation(
         summary = "delete a entity",
-        description = "received a `dataId` as pathVariable and try to remove the data in database"
+        description = "receives a `dataId` as pathVariable and try to remove the data in database"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
@@ -1,21 +1,70 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 import the.coding.force.exploring_kotlin_coroutines.service.coroutine.ReadDataServiceCoroutine
 
 @RestController
 @RequestMapping("/api/coroutine")
+@Tag(name = "coroutine", description = "operations in coroutine context")
 class ReadControllerCoroutine(
     private val readDataService: ReadDataServiceCoroutine
 ) {
 
+    @Operation(
+        summary = "get a entity",
+        description = "received a `dataId` as pathVariable and try to get the data in database"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "404",
+            description = "not found",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                        "status": 404,
+                        "error": "NOT_FOUND",
+                        "message": "Data with ID x was not found to retrieve it",
+                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                        "path": "/api/coroutine/delete/10"
+                    }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @GetMapping("read/{id}")
-    suspend fun read(@PathVariable("id") dataId: Long): ResponseEntity<ReadDataResponse> {
+    suspend fun read(
+        @Parameter(
+            name = "id",
+            description = "Unique identifier of the data to get in the database",
+            required = true,
+            example = "10",
+            schema = Schema(type = "long", format = "int64", minimum = "1"),
+        )
+        @PathVariable("id") dataId: Long
+
+    ): ResponseEntity<ReadDataResponse> {
         val data = readDataService.read(dataId)
         return ResponseEntity.ok(data)
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
@@ -40,13 +40,13 @@ class ReadControllerCoroutine(
                     examples = [
                         ExampleObject(
                             value = """{
-                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
-                        "status": 404,
-                        "error": "NOT_FOUND",
-                        "message": "Data with ID x was not found to retrieve it",
-                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                        "path": "/api/coroutine/delete/10"
-                    }"""
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 404,
+                            "error": "NOT_FOUND",
+                            "message": "Data with ID x was not found to retrieve it",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                            "path": "/api/coroutine/delete/10"
+                           }"""
                         )
                     ]
                 )
@@ -63,7 +63,6 @@ class ReadControllerCoroutine(
             schema = Schema(type = "long", format = "int64", minimum = "1"),
         )
         @PathVariable("id") dataId: Long
-
     ): ResponseEntity<ReadDataResponse> {
         val data = readDataService.read(dataId)
         return ResponseEntity.ok(data)

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
@@ -26,7 +26,7 @@ class ReadControllerCoroutine(
 
     @Operation(
         summary = "get a entity",
-        description = "received a `dataId` as pathVariable and try to get the data in database"
+        description = "receives a `dataId` as pathVariable and try to get the data in database"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
@@ -29,7 +29,7 @@ class UpdateControllerCoroutine(
 
     @Operation(
         summary = "update a entity",
-        description = "received a `dataId` as pathVariable and an UpdateDataRequest as requestBody and try to update the data in database"
+        description = "receives a `dataId` as pathVariable and an UpdateDataRequest as requestBody and try to update the data in database"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
@@ -43,13 +43,13 @@ class UpdateControllerCoroutine(
                     examples = [
                         ExampleObject(
                             value = """{
-                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
-                        "status": 404,
-                        "error": "NOT_FOUND",
-                        "message": "Data with ID x was not found for update",
-                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                        "path": "/api/coroutine/delete/10"
-                    }"""
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 404,
+                            "error": "NOT_FOUND",
+                            "message": "Data with ID x was not found for update",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                            "path": "/api/coroutine/delete/10"
+                           }"""
                         )
                     ]
                 )
@@ -67,6 +67,7 @@ class UpdateControllerCoroutine(
         )
         @PathVariable("id") dataId: Long,
 
+        // renamed the requestBody reference from swagger to prevent conflicts of the same name
         @RequestBodySwagger(
             description = "DTO (data transfer object) used to update a entity in database",
             required = true,

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
@@ -1,23 +1,82 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
 import the.coding.force.exploring_kotlin_coroutines.request.UpdateDataRequest
 import the.coding.force.exploring_kotlin_coroutines.service.coroutine.UpdateDataServiceCoroutine
+import io.swagger.v3.oas.annotations.parameters.RequestBody as RequestBodySwagger
 
 @RestController
 @RequestMapping("/api/coroutine")
+@Tag(name = "coroutine", description = "operations in coroutine context")
 class UpdateControllerCoroutine(
     private val updateDataService: UpdateDataServiceCoroutine
 ) {
+
+    @Operation(
+        summary = "update a entity",
+        description = "received a `dataId` as pathVariable and an UpdateDataRequest as requestBody and try to update the data in database"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "404",
+            description = "not found",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                        "status": 404,
+                        "error": "NOT_FOUND",
+                        "message": "Data with ID x was not found for update",
+                        "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                        "path": "/api/coroutine/delete/10"
+                    }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @PutMapping("update/{id}")
     suspend fun update(
+        @Parameter(
+            name = "id",
+            description = "Unique identifier of the data to update in the database",
+            required = true,
+            example = "10",
+            schema = Schema(type = "long", format = "int64", minimum = "1"),
+        )
         @PathVariable("id") dataId: Long,
+
+        @RequestBodySwagger(
+            description = "DTO (data transfer object) used to update a entity in database",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = UpdateDataRequest::class),
+                )
+            ]
+        )
         @RequestBody request: UpdateDataRequest
     ): ResponseEntity<Unit> = updateDataService
         .update(request.toDto(dataId))

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/handler/GlobalExceptionHandler.kt
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import org.springframework.web.context.request.WebRequest
+import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException
 import java.time.ZonedDateTime
@@ -14,22 +14,22 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     private fun createNewResponseError(
         status: HttpStatus,
         exception: Throwable,
-        request: WebRequest
+        request: ServletWebRequest
     ): ResponseError {
         return ResponseError(
             ZonedDateTime.now(),
             status.value(),
             status.name,
             exception.message ?: "default message",
-            exception,
-            request.contextPath
+            exception.javaClass.name,
+            request.request.requestURI
         )
     }
 
     @ExceptionHandler(DataNotFoundException::class)
     fun handlerDataNotFoundException(
         exception: DataNotFoundException,
-        request: WebRequest
+        request: ServletWebRequest
     ): ResponseEntity<ResponseError> {
         return ResponseEntity(
             createNewResponseError(
@@ -38,6 +38,21 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
                 request
             ),
             HttpStatus.NOT_FOUND
+        )
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleGenericException(
+        exception: Exception,
+        request: ServletWebRequest
+    ): ResponseEntity<ResponseError> {
+        return ResponseEntity(
+            createNewResponseError(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                exception,
+                request
+            ),
+            HttpStatus.INTERNAL_SERVER_ERROR
         )
     }
 }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/handler/ResponseError.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/handler/ResponseError.kt
@@ -1,12 +1,42 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.handler
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZonedDateTime
-
+@Schema(description = "An error model object to send case an expect or unexpected error occurred")
 data class ResponseError(
+    @Schema(
+        description = "the time that occurred the exception with time zone",
+        example = "2024-12-11T13:19:14.083776445-03:00",
+    )
     val timestamp: ZonedDateTime,
+
+    @Schema(
+        description = "the status code that references the exception threw",
+        example = "404"
+    )
     val status: Int,
+
+    @Schema(
+        description = "the name of status that references the exception threw",
+        example = "NOT_FOUND"
+    )
     val error: String,
+
+    @Schema(
+        description = "the message that is threw in exception",
+        example = "Data with ID x was not found to retrieve it"
+    )
     val message: String,
+
+    @Schema(
+        description = "the class of exception that is threw",
+        example = "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException"
+    )
     val exceptionClass: String,
+
+    @Schema(
+        description = "the path of controller that was called to send the request",
+        example = "/api/coroutine/delete/10"
+    )
     val path: String
 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/handler/ResponseError.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/handler/ResponseError.kt
@@ -7,6 +7,6 @@ data class ResponseError(
     val status: Int,
     val error: String,
     val message: String,
-    val exception: Throwable,
+    val exceptionClass: String,
     val path: String
 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/BulkCreateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/BulkCreateController.kt
@@ -29,7 +29,7 @@ class BulkCreateController(
 ) {
     @Operation(
         summary = "create several data in database outside of a coroutine context",
-        description = "received a `BulkCreateDataRequest` that contains the quantity of data to save in database and the status"
+        description = "receives a `BulkCreateDataRequest` that contains the quantity of data to save in database and the status"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/BulkCreateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/BulkCreateController.kt
@@ -1,22 +1,75 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
 import the.coding.force.exploring_kotlin_coroutines.request.BulkCreateDataRequest
 import the.coding.force.exploring_kotlin_coroutines.service.withoutCoroutine.BulkCreateDataService
+import io.swagger.v3.oas.annotations.parameters.RequestBody as RequestBodySwagger
 
 @RestController
 @RequestMapping("/api")
+@Tag(
+    name = "load test endpoints",
+    description = "these endpoints are about load test to save several data in database"
+)
 class BulkCreateController(
     private val bulkCreateDataService: BulkCreateDataService
 ) {
-
+    @Operation(
+        summary = "create several data in database outside of a coroutine context",
+        description = "received a `BulkCreateDataRequest` that contains the quantity of data to save in database and the status"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exceṕtion", 
+                            "path": "/api/coroutine/create"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @PostMapping("/bulk/create")
-    fun create(@RequestBody request: BulkCreateDataRequest): ResponseEntity<Unit> {
+    fun create(
+        @RequestBodySwagger(
+            description = "DTO (data transfer object) used to save a new entity in database",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = BulkCreateDataRequest::class),
+                )
+            ]
+        )
+        @RequestBody request: BulkCreateDataRequest
+    ): ResponseEntity<Unit> {
         bulkCreateDataService.create(request.quantity, request.toDto())
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateController.kt
@@ -1,22 +1,73 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
 import the.coding.force.exploring_kotlin_coroutines.request.CreateDataRequest
 import the.coding.force.exploring_kotlin_coroutines.service.withoutCoroutine.CreateDataService
+import io.swagger.v3.oas.annotations.parameters.RequestBody as RequestBodySwagger
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "without-coroutine", description = "operations outside of a coroutine context")
 class CreateController(
     private val createDataService: CreateDataService
 ) {
-
+    @Operation(
+        summary = "create a DataEntity",
+        description = "received a `CreateDataRequest` as body and convert to DTO to save in database",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exception", 
+                            "path": "/api/coroutine/create"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @PostMapping("/create")
-    fun create(@RequestBody request: CreateDataRequest): ResponseEntity<Unit> = createDataService
+    fun create(
+        // renamed the requestBody reference from swagger to prevent conflicts of the same name
+        @RequestBodySwagger(
+            description = "DTO (data transfer object) used to save a new entity in database",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = CreateDataRequest::class),
+                )
+            ]
+        )
+        @RequestBody request: CreateDataRequest
+    ): ResponseEntity<Unit> = createDataService
         .create(request.toDto())
         .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateController.kt
@@ -26,7 +26,7 @@ class CreateController(
 ) {
     @Operation(
         summary = "create a DataEntity",
-        description = "received a `CreateDataRequest` as body and convert to DTO to save in database",
+        description = "receives a `CreateDataRequest` as body and convert to DTO to save in database",
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteController.kt
@@ -1,19 +1,67 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.service.withoutCoroutine.DeleteDataService
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "without-coroutine", description = "operations outside of a coroutine context")
 class DeleteController(
     private val deleteDataService: DeleteDataService
 ) {
+    @Operation(
+        summary = "delete a entity",
+        description = "received a `dataId` as pathVariable and try to remove the data in database"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "404",
+            description = "not found",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 404,
+                            "error": "NOT_FOUND",
+                            "message": "Data with ID x was not found for deletion",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                            "path": "/api/coroutine/delete/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @DeleteMapping("/delete/{id}")
-    fun delete(@PathVariable("id") dataId: Long): ResponseEntity<Unit> {
+    fun delete(
+        @Parameter(
+            name = "id",
+            description = "Unique identifier of the data to delete in the database",
+            required = true,
+            example = "10",
+            schema = Schema(type = "long", format = "int64", minimum = "1")
+        )
+        @PathVariable("id") dataId: Long
+    ): ResponseEntity<Unit> {
         deleteDataService.delete(dataId)
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteController.kt
@@ -24,7 +24,7 @@ class DeleteController(
 ) {
     @Operation(
         summary = "delete a entity",
-        description = "received a `dataId` as pathVariable and try to remove the data in database"
+        description = "receives a `dataId` as pathVariable and try to remove the data in database"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadController.kt
@@ -1,20 +1,68 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 import the.coding.force.exploring_kotlin_coroutines.service.withoutCoroutine.ReadDataService
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "without-coroutine", description = "operations outside of a coroutine context")
 class ReadController(
     private val readDataService: ReadDataService
 ) {
+    @Operation(
+        summary = "get a entity",
+        description = "received a `dataId` as pathVariable and try to get the data in database"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "404",
+            description = "not found",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 404,
+                            "error": "NOT_FOUND",
+                            "message": "Data with ID x was not found to retrieve it",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                            "path": "/api/coroutine/delete/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @GetMapping("/read/{id}")
-    fun read(@PathVariable("id") dataId: Long): ResponseEntity<ReadDataResponse> {
+    fun read(
+        @Parameter(
+            name = "id",
+            description = "Unique identifier of the data to get in the database",
+            required = true,
+            example = "10",
+            schema = Schema(type = "long", format = "int64", minimum = "1"),
+        )
+        @PathVariable("id") dataId: Long
+    ): ResponseEntity<ReadDataResponse> {
         val response = readDataService.read(dataId)
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadController.kt
@@ -25,7 +25,7 @@ class ReadController(
 ) {
     @Operation(
         summary = "get a entity",
-        description = "received a `dataId` as pathVariable and try to get the data in database"
+        description = "receives a `dataId` as pathVariable and try to get the data in database"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateController.kt
@@ -1,23 +1,82 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
 import the.coding.force.exploring_kotlin_coroutines.request.UpdateDataRequest
 import the.coding.force.exploring_kotlin_coroutines.service.withoutCoroutine.UpdateDataService
+import io.swagger.v3.oas.annotations.parameters.RequestBody as RequestBodySwagger
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "without-coroutine", description = "operations outside of a coroutine context")
 class UpdateController(
     private val updateDataService: UpdateDataService
 ) {
+    @Operation(
+        summary = "update a entity",
+        description = "received a `dataId` as pathVariable and an UpdateDataRequest as requestBody and try to update the data in database"
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "success"),
+        ApiResponse(
+            responseCode = "404",
+            description = "not found",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 404,
+                            "error": "NOT_FOUND",
+                            "message": "Data with ID x was not found for update",
+                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
+                            "path": "/api/coroutine/delete/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        )
+    )
     @PutMapping("/update/{id}")
     fun update(
+        @Parameter(
+            name = "id",
+            description = "Unique identifier of the data to update in the database",
+            required = true,
+            example = "10",
+            schema = Schema(type = "long", format = "int64", minimum = "1"),
+        )
         @PathVariable("id") dataId: Long,
+
+        // renamed the requestBody reference from swagger to prevent conflicts of the same name
+        @RequestBodySwagger(
+            description = "DTO (data transfer object) used to update a entity in database",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = UpdateDataRequest::class),
+                )
+            ]
+        )
         @RequestBody request: UpdateDataRequest
     ): ResponseEntity<Unit> = updateDataService
         .update(request.toDto(dataId))

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateController.kt
@@ -28,7 +28,7 @@ class UpdateController(
 ) {
     @Operation(
         summary = "update a entity",
-        description = "received a `dataId` as pathVariable and an UpdateDataRequest as requestBody and try to update the data in database"
+        description = "receives a `dataId` as pathVariable and an UpdateDataRequest as requestBody and try to update the data in database"
     )
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/request/BulkCreateDataRequest.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/request/BulkCreateDataRequest.kt
@@ -1,8 +1,21 @@
 package the.coding.force.exploring_kotlin_coroutines.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
+@Schema(
+    description = "A DTO (data transfer object) used to send on request " +
+        "for save several entities how load test"
+)
 data class BulkCreateDataRequest(
+    @Schema(
+        description = "Quantity of entities to save in database",
+        example = "500"
+    )
     val quantity: Int,
+
+    @Schema(
+        description = "A Enum that represents the status of task"
+    )
     val status: DataStatusEnum?
 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/request/CreateDataRequest.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/request/CreateDataRequest.kt
@@ -1,7 +1,14 @@
 package the.coding.force.exploring_kotlin_coroutines.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
+@Schema(
+    description = "A DTO (data transfer object) used to send on request for save a entity"
+)
 data class CreateDataRequest(
+    @Schema(
+        description = "A Enum that represents the status of task"
+    )
     val status: DataStatusEnum?
 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/request/UpdateDataRequest.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/request/UpdateDataRequest.kt
@@ -1,7 +1,13 @@
 package the.coding.force.exploring_kotlin_coroutines.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
-
+@Schema(
+    description = "A DTO (data transfer object) used to send on request for update a entity"
+)
 data class UpdateDataRequest(
+    @Schema(
+        description = "A Enum that represents the status of task"
+    )
     val status: DataStatusEnum
 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/response/ReadDataResponse.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/response/ReadDataResponse.kt
@@ -1,5 +1,13 @@
 package the.coding.force.exploring_kotlin_coroutines.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "A DTO (data transfer object) used how response for the read service"
+)
 data class ReadDataResponse(
+    @Schema(
+        description = "A String that represents the status of task returned in database for read operation"
+    )
     val status: String
 )

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/BulkCreateDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/BulkCreateDataServiceCoroutine.kt
@@ -10,12 +10,31 @@ import the.coding.force.exploring_kotlin_coroutines.dto.BulkCreateDataDto
 import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * Service responsible for testing the speed of I/O operations involving multiple `DataEntity` instances.
+ * It performs asynchronous creation of entities using coroutines to improve performance.
+ *
+ * @author José Iêdo
+ * @param dataRepository Repository used to persist instances of `DataEntity`.
+ */
 @Service
 class BulkCreateDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
+    // Logger to record the status of the execution of the `create` suspend function.
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * Creates a list of `DataEntity` instances in the database asynchronously.
+     *
+     * For each value in `quantity`, a coroutine is launched to execute a task asynchronously.
+     * Once all coroutines are created, the `awaitAll` function waits for their completion.
+     * After all coroutines finish, a success message is logged.
+     *
+     * @param quantity Number of `DataEntity` instances to be saved in the database.
+     * @param dto Data Transfer Object (DTO) received from the controller `create`.
+     * @return `Unit` (no return value).
+     */
     suspend fun create(quantity: Int, dto: BulkCreateDataDto) = coroutineScope {
         val coroutines = (1..quantity).map { index ->
             async {
@@ -30,6 +49,12 @@ class BulkCreateDataServiceCoroutine(
         logger.info { "BulkCreateDataService.create with coroutine, all entities saved" }
     }
 
+    /**
+     * Simulates an asynchronous external network call.
+     * Used to test asynchronous operations within the `create` method.
+     *
+     * @throws InterruptedException if the delay is interrupted.
+     */
     suspend fun fakeNetworkCall() {
         delay(1000)
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/BulkCreateDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/BulkCreateDataServiceCoroutine.kt
@@ -11,9 +11,6 @@ import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * Service responsible for testing the speed of I/O operations involving multiple `DataEntity` instances.
- * It performs asynchronous creation of entities using coroutines to improve performance.
- *
  * @author José Iêdo
  * @param dataRepository Repository used to persist instances of `DataEntity`.
  */
@@ -21,19 +18,11 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class BulkCreateDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
-    // Logger to record the status of the execution of the `create` suspend function.
     private val logger = KotlinLogging.logger { }
 
     /**
-     * Creates a list of `DataEntity` instances in the database asynchronously.
-     *
-     * For each value in `quantity`, a coroutine is launched to execute a task asynchronously.
-     * Once all coroutines are created, the `awaitAll` function waits for their completion.
-     * After all coroutines finish, a success message is logged.
-     *
      * @param quantity Number of `DataEntity` instances to be saved in the database.
      * @param dto Data Transfer Object (DTO) received from the controller `create`.
-     * @return `Unit` (no return value).
      */
     suspend fun create(quantity: Int, dto: BulkCreateDataDto) = coroutineScope {
         val coroutines = (1..quantity).map { index ->
@@ -50,10 +39,7 @@ class BulkCreateDataServiceCoroutine(
     }
 
     /**
-     * Simulates an asynchronous external network call.
-     * Used to test asynchronous operations within the `create` method.
-     *
-     * @throws InterruptedException if the delay is interrupted.
+     * @author Jose Iêdo
      */
     suspend fun fakeNetworkCall() {
         delay(1000)

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/CreateDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/CreateDataServiceCoroutine.kt
@@ -8,12 +8,30 @@ import the.coding.force.exploring_kotlin_coroutines.dto.CreateDataDto
 import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * This Service has the suspend method `create` inside coroutine context to create a `DataEntity`
+ *
+ * @author Lucas Terra
+ * @param dataRepository repository from `DataEntity`
+ * @property create suspend method to create a `DataEntity` in coroutine context
+ */
 @Service
 class CreateDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
+    // logger to register the status of suspend method creates
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * received a `dataDto` from suspend controller create and convert it in a `DataEntity`
+     * to save in database inside a coroutine context, after this the logger will register the status
+     * of create operation
+     *
+     * @author Lucas Terra
+     * @param createDataDto data transfer object received from suspend controller `create`
+     * @return `Unit`
+     * @see logger
+     */
     suspend fun create(createDataDto: CreateDataDto) {
         withContext(Dispatchers.IO) {
             dataRepository.save(createDataDto.toEntity())

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/CreateDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/CreateDataServiceCoroutine.kt
@@ -9,8 +9,6 @@ import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * This Service has the suspend method `create` inside coroutine context to create a `DataEntity`
- *
  * @author Lucas Terra
  * @param dataRepository repository from `DataEntity`
  * @property create suspend method to create a `DataEntity` in coroutine context
@@ -19,18 +17,12 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class CreateDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
-    // logger to register the status of suspend method creates
     private val logger = KotlinLogging.logger { }
 
     /**
-     * received a `dataDto` from suspend controller create and convert it in a `DataEntity`
-     * to save in database inside a coroutine context, after this the logger will register the status
-     * of create operation
-     *
      * @author Lucas Terra
      * @param createDataDto data transfer object received from suspend controller `create`
      * @return `Unit`
-     * @see logger
      */
     suspend fun create(createDataDto: CreateDataDto) {
         withContext(Dispatchers.IO) {

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/DeleteDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/DeleteDataServiceCoroutine.kt
@@ -7,12 +7,32 @@ import org.springframework.stereotype.Service
 import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * This Service has the suspend method `delete` inside coroutine context to delete a `DataEntity`
+ *
+ * @author Lucas Terra
+ * @param dataRepository repository from `DataEntity`
+ * @property delete suspend method to delete a `DataEntity` in coroutine context
+ */
 @Service
 class DeleteDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
+    // logger to register the status of suspend method delete
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * Received a `dataId` from suspend controller `delete` and try to find the data to delete it,
+     * if the data exists it will be deleted in the database, case the data does not exist an exception
+     * `DataNotFoundException` will be thrown.
+     * The logger will register the status of delete operation
+     *
+     * @author Lucas Terra
+     * @param dataId ID from `DataEntity` received from suspend controller `delete` to find in the database
+     * @return `Unit`
+     * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
+     * @see logger
+     */
     suspend fun delete(dataId: Long) {
         withContext(Dispatchers.IO) {
             dataRepository.findById(dataId).ifPresentOrElse(

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/DeleteDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/DeleteDataServiceCoroutine.kt
@@ -8,8 +8,6 @@ import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundExcept
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * This Service has the suspend method `delete` inside coroutine context to delete a `DataEntity`
- *
  * @author Lucas Terra
  * @param dataRepository repository from `DataEntity`
  * @property delete suspend method to delete a `DataEntity` in coroutine context
@@ -18,20 +16,12 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class DeleteDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
-    // logger to register the status of suspend method delete
     private val logger = KotlinLogging.logger { }
 
     /**
-     * Received a `dataId` from suspend controller `delete` and try to find the data to delete it,
-     * if the data exists it will be deleted in the database, case the data does not exist an exception
-     * `DataNotFoundException` will be thrown.
-     * The logger will register the status of delete operation
-     *
      * @author Lucas Terra
      * @param dataId ID from `DataEntity` received from suspend controller `delete` to find in the database
-     * @return `Unit`
      * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
-     * @see logger
      */
     suspend fun delete(dataId: Long) {
         withContext(Dispatchers.IO) {

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/ReadDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/ReadDataServiceCoroutine.kt
@@ -9,8 +9,6 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 
 /**
- * This Service has the suspend method `read` inside coroutine context to get a `ReadDataResponse`
- *
  * @author Lucas Terra
  * @param dataRepository repository from DataEntity
  * @property read suspend method to get a `ReadDataResponse` in coroutine context
@@ -19,20 +17,14 @@ import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 class ReadDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
-    // logger to register the status of suspend method read
     private val logger = KotlinLogging.logger { }
 
     /**
-     * received a `dataId` from suspend controller `read` and try to find the data to get it,
-     * if the data exists it will be got in the database, case the data does not exist an exception
-     * DataNotFoundException` will be thrown. The `logger` will register the status of read operation
-     *
      * @author Lucas Terra
      * @param dataId ID from `DataEntity` received from suspend controller `read` to find in the database
      * @return `ReadDataResponse` case a register exists in the database
      * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
      * @see ReadDataResponse
-     * @see logger
      */
     suspend fun read(dataId: Long): ReadDataResponse {
         return withContext(Dispatchers.IO) {

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/ReadDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/ReadDataServiceCoroutine.kt
@@ -8,12 +8,32 @@ import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundExcept
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 
+/**
+ * This Service has the suspend method `read` inside coroutine context to get a `ReadDataResponse`
+ *
+ * @author Lucas Terra
+ * @param dataRepository repository from DataEntity
+ * @property read suspend method to get a `ReadDataResponse` in coroutine context
+ */
 @Service
 class ReadDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
+    // logger to register the status of suspend method read
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * received a `dataId` from suspend controller `read` and try to find the data to get it,
+     * if the data exists it will be got in the database, case the data does not exist an exception
+     * DataNotFoundException` will be thrown. The `logger` will register the status of read operation
+     *
+     * @author Lucas Terra
+     * @param dataId ID from `DataEntity` received from suspend controller `read` to find in the database
+     * @return `ReadDataResponse` case a register exists in the database
+     * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
+     * @see ReadDataResponse
+     * @see logger
+     */
     suspend fun read(dataId: Long): ReadDataResponse {
         return withContext(Dispatchers.IO) {
             dataRepository.findById(dataId)

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/UpdateDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/UpdateDataServiceCoroutine.kt
@@ -10,8 +10,6 @@ import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundExcept
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * This Service has the suspend method `update` inside coroutine context to update a `DataEntity`
- *
  * @author Adriano Santos
  * @param dataRepository repository from DataEntity
  * @property update suspend method to update a `DataEntity` in coroutine context
@@ -20,22 +18,13 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class UpdateDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
-    // logger to register the status of suspend method update
     private val logger = KotlinLogging.logger { }
 
     /**
-     * received a `UpdateDataDto` from suspend controller `update`
-     * and try to find the data to update it with the new information, if the data exists
-     * it will be updated with UpdateDataDto status info, case the data does not exist an exception
-     * `DataNotFoundException` will be thrown.
-     * The `logger` will register the status of update operation
-     *
      * @author Adriano Santos
      * @param dto is a data transfer objet from UpdateDataDto received from controller update
-     * @return `Unit`
      * @throws DataNotFoundException when the data with `ID` inside UpdateDataDto was not found this exception is thrown
      * @see UpdateDataDto
-     * @see logger
      */
     suspend fun update(dto: UpdateDataDto): DataEntity = withContext(Dispatchers.IO) {
         dataRepository.findById(dto.id)

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/UpdateDataServiceCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/coroutine/UpdateDataServiceCoroutine.kt
@@ -9,12 +9,34 @@ import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * This Service has the suspend method `update` inside coroutine context to update a `DataEntity`
+ *
+ * @author Adriano Santos
+ * @param dataRepository repository from DataEntity
+ * @property update suspend method to update a `DataEntity` in coroutine context
+ */
 @Service
 class UpdateDataServiceCoroutine(
     private val dataRepository: DataRepository,
 ) {
+    // logger to register the status of suspend method update
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * received a `UpdateDataDto` from suspend controller `update`
+     * and try to find the data to update it with the new information, if the data exists
+     * it will be updated with UpdateDataDto status info, case the data does not exist an exception
+     * `DataNotFoundException` will be thrown.
+     * The `logger` will register the status of update operation
+     *
+     * @author Adriano Santos
+     * @param dto is a data transfer objet from UpdateDataDto received from controller update
+     * @return `Unit`
+     * @throws DataNotFoundException when the data with `ID` inside UpdateDataDto was not found this exception is thrown
+     * @see UpdateDataDto
+     * @see logger
+     */
     suspend fun update(dto: UpdateDataDto): DataEntity = withContext(Dispatchers.IO) {
         dataRepository.findById(dto.id)
             .map { data ->

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/BulkCreateDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/BulkCreateDataService.kt
@@ -8,9 +8,6 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 import java.util.concurrent.CompletableFuture
 
 /**
- * Service responsible for testing the speed of I/O operations involving multiple `DataEntity` instances.
- * It performs asynchronous creation of entities using `CompletableFuture` java class to improve performance.
- *
  * @author José Iêdo
  * @param dataRepository Repository used to persist instances of `DataEntity`.
  */
@@ -18,20 +15,12 @@ import java.util.concurrent.CompletableFuture
 class BulkCreateDataService(
     private val dataRepository: DataRepository,
 ) {
-    // Logger to record the status of the execution of the `create` function.
     private val logger = KotlinLogging.logger { }
 
     /**
-     * Creates a list of `DataEntity` instances in the database asynchronously.
-     * For each value in `quantity`, a `supplyAsync` block is launched to execute a task asynchronously.
-     * Once all `supplyAsync` blocks are created and stored in a variable jobs
-     * the `allOf` function  from `CompletableFuture` waits for their completion.
-     * After all tasks finish, a success message is logged.
-     *
      * @author Jose Iêdo
      * @param quantity Number of `DataEntity` instances to be saved in the database.
      * @param dto Data Transfer Object (DTO) received from the controller `create`.
-     * @return `Unit` (no return value).
      */
     fun create(quantity: Int, dto: BulkCreateDataDto) {
         val jobs = (1..quantity).map { index ->
@@ -48,9 +37,6 @@ class BulkCreateDataService(
     }
 
     /**
-     * Simulates an asynchronous external network call.
-     * Used to test asynchronous operations within the `create` method.
-     *
      * @author Jose Iêdo
      * @throws InterruptedException if the delay is interrupted.
      * @throws IllegalArgumentException if the value of millis is negative

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/BulkCreateDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/BulkCreateDataService.kt
@@ -7,12 +7,32 @@ import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Service responsible for testing the speed of I/O operations involving multiple `DataEntity` instances.
+ * It performs asynchronous creation of entities using `CompletableFuture` java class to improve performance.
+ *
+ * @author José Iêdo
+ * @param dataRepository Repository used to persist instances of `DataEntity`.
+ */
 @Service
 class BulkCreateDataService(
     private val dataRepository: DataRepository,
 ) {
+    // Logger to record the status of the execution of the `create` function.
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * Creates a list of `DataEntity` instances in the database asynchronously.
+     * For each value in `quantity`, a `supplyAsync` block is launched to execute a task asynchronously.
+     * Once all `supplyAsync` blocks are created and stored in a variable jobs
+     * the `allOf` function  from `CompletableFuture` waits for their completion.
+     * After all tasks finish, a success message is logged.
+     *
+     * @author Jose Iêdo
+     * @param quantity Number of `DataEntity` instances to be saved in the database.
+     * @param dto Data Transfer Object (DTO) received from the controller `create`.
+     * @return `Unit` (no return value).
+     */
     fun create(quantity: Int, dto: BulkCreateDataDto) {
         val jobs = (1..quantity).map { index ->
             CompletableFuture.supplyAsync {
@@ -27,6 +47,14 @@ class BulkCreateDataService(
         logger.info { "BulkCreateDataService.create without coroutines, all entities saved" }
     }
 
+    /**
+     * Simulates an asynchronous external network call.
+     * Used to test asynchronous operations within the `create` method.
+     *
+     * @author Jose Iêdo
+     * @throws InterruptedException if the delay is interrupted.
+     * @throws IllegalArgumentException if the value of millis is negative
+     */
     fun fakeNetworkCall() {
         Thread.sleep(1000)
     }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/CreateDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/CreateDataService.kt
@@ -7,8 +7,6 @@ import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * This Service has the method `create` to create a `DataEntity`
- *
  * @author Adriano Santos
  * @param dataRepository repository from `DataEntity`
  * @property create method to create a `DataEntity`
@@ -17,17 +15,11 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class CreateDataService(
     private val dataRepository: DataRepository
 ) {
-    // logger to register the status of method `create`
     private val logger = KotlinLogging.logger { }
 
     /**
-     * received a `dataDto` from controller create and convert it in a `DataEntity`to save in the database,
-     * after this the logger will register the status of create operation
-     *
      * @author Adriano Santos
      * @param dto data transfer object received from controller `create`
-     * @return `Unit`
-     * @see logger
      */
     fun create(dto: CreateDataDto) = dataRepository
         .save(dto.toEntity())

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/CreateDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/CreateDataService.kt
@@ -6,12 +6,29 @@ import the.coding.force.exploring_kotlin_coroutines.dto.CreateDataDto
 import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * This Service has the method `create` to create a `DataEntity`
+ *
+ * @author Adriano Santos
+ * @param dataRepository repository from `DataEntity`
+ * @property create method to create a `DataEntity`
+ */
 @Service
 class CreateDataService(
     private val dataRepository: DataRepository
 ) {
+    // logger to register the status of method `create`
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * received a `dataDto` from controller create and convert it in a `DataEntity`to save in the database,
+     * after this the logger will register the status of create operation
+     *
+     * @author Adriano Santos
+     * @param dto data transfer object received from controller `create`
+     * @return `Unit`
+     * @see logger
+     */
     fun create(dto: CreateDataDto) = dataRepository
         .save(dto.toEntity())
         .also { logger.info { "CreateDataService.create, entity saved:$this" } }

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/DeleteDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/DeleteDataService.kt
@@ -5,12 +5,32 @@ import org.springframework.stereotype.Service
 import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * This Service has the method `delete` to delete a `DataEntity`
+ *
+ * @author Lucas Terra
+ * @param dataRepository repository from `DataEntity`
+ * @property delete method to delete a `DataEntity`
+ */
 @Service
 class DeleteDataService(
     private val dataRepository: DataRepository
 ) {
+    // logger to register the status of method `delete`
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * Received a `dataId` from controller `delete` and try to find the data to delete it,
+     * if the data exists it will be deleted in the database, case the data does not exist an exception
+     * `DataNotFoundException` will be thrown.
+     * The logger will register the status of delete operation
+     *
+     * @author Lucas Terra
+     * @param dataId ID from `DataEntity` received from controller `delete` to find in the database
+     * @return `Unit`
+     * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
+     * @see logger
+     */
     fun delete(dataId: Long) {
         dataRepository.findById(dataId)
             .ifPresentOrElse(

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/DeleteDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/DeleteDataService.kt
@@ -6,8 +6,6 @@ import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundExcept
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * This Service has the method `delete` to delete a `DataEntity`
- *
  * @author Lucas Terra
  * @param dataRepository repository from `DataEntity`
  * @property delete method to delete a `DataEntity`
@@ -16,20 +14,12 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class DeleteDataService(
     private val dataRepository: DataRepository
 ) {
-    // logger to register the status of method `delete`
     private val logger = KotlinLogging.logger { }
 
     /**
-     * Received a `dataId` from controller `delete` and try to find the data to delete it,
-     * if the data exists it will be deleted in the database, case the data does not exist an exception
-     * `DataNotFoundException` will be thrown.
-     * The logger will register the status of delete operation
-     *
      * @author Lucas Terra
      * @param dataId ID from `DataEntity` received from controller `delete` to find in the database
-     * @return `Unit`
      * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
-     * @see logger
      */
     fun delete(dataId: Long) {
         dataRepository.findById(dataId)

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/ReadDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/ReadDataService.kt
@@ -6,12 +6,32 @@ import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundExcept
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 
+/**
+ * This Service has the method `read` to get a `ReadDataResponse`
+ *
+ * @author Lucas Terra
+ * @param dataRepository repository from DataEntity
+ * @property read method to get a `ReadDataResponse`
+ */
 @Service
 class ReadDataService(
     private val dataRepository: DataRepository
 ) {
+    // logger to register the status of method `read`
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * received a `dataId` from controller `read` and try to find the data to get it,
+     * if the data exists it will be got in the database, case the data does not exist an exception
+     * DataNotFoundException` will be thrown. The `logger` will register the status of read operation
+     *
+     * @author Lucas Terra
+     * @param dataId ID from `DataEntity` received from controller `read` to find in the database
+     * @return `ReadDataResponse` case a register exists in the database
+     * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
+     * @see ReadDataResponse
+     * @see logger
+     */
     fun read(dataId: Long): ReadDataResponse {
         return dataRepository.findById(dataId)
             .map { data ->

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/ReadDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/ReadDataService.kt
@@ -7,8 +7,6 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 
 /**
- * This Service has the method `read` to get a `ReadDataResponse`
- *
  * @author Lucas Terra
  * @param dataRepository repository from DataEntity
  * @property read method to get a `ReadDataResponse`
@@ -17,20 +15,14 @@ import the.coding.force.exploring_kotlin_coroutines.response.ReadDataResponse
 class ReadDataService(
     private val dataRepository: DataRepository
 ) {
-    // logger to register the status of method `read`
     private val logger = KotlinLogging.logger { }
 
     /**
-     * received a `dataId` from controller `read` and try to find the data to get it,
-     * if the data exists it will be got in the database, case the data does not exist an exception
-     * DataNotFoundException` will be thrown. The `logger` will register the status of read operation
-     *
      * @author Lucas Terra
      * @param dataId ID from `DataEntity` received from controller `read` to find in the database
      * @return `ReadDataResponse` case a register exists in the database
      * @throws DataNotFoundException when the data with `DataId` was not found this exception is thrown
      * @see ReadDataResponse
-     * @see logger
      */
     fun read(dataId: Long): ReadDataResponse {
         return dataRepository.findById(dataId)

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/UpdateDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/UpdateDataService.kt
@@ -6,12 +6,34 @@ import the.coding.force.exploring_kotlin_coroutines.dto.UpdateDataDto
 import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
+/**
+ * This Service has the method `update` to update a `DataEntity`
+ *
+ * @author Lucas Terra
+ * @param dataRepository repository from DataEntity
+ * @property update method to update a `DataEntity`
+ */
 @Service
 class UpdateDataService(
     private val dataRepository: DataRepository
 ) {
+    // logger to register the status of method update
     private val logger = KotlinLogging.logger { }
 
+    /**
+     * received a `UpdateDataDto` from controller `update`
+     * and try to find the data to update it with the new information,
+     * if the data exists it will be updated with UpdateDataDto status info,
+     * case the data does not exist an exception `DataNotFoundException` will be thrown.
+     * The `logger` will register the status of update operation
+     *
+     * @author Adriano Santos
+     * @param dto is a data transfer objet from UpdateDataDto received from controller update
+     * @return `Unit`
+     * @throws DataNotFoundException when the data with `ID` inside UpdateDataDto was not found this exception is thrown
+     * @see UpdateDataDto
+     * @see logger
+     */
     fun update(dto: UpdateDataDto) {
         dataRepository.findById(dto.id)
             .map { data ->

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/UpdateDataService.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/service/withoutCoroutine/UpdateDataService.kt
@@ -7,8 +7,6 @@ import the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundExcept
 import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 
 /**
- * This Service has the method `update` to update a `DataEntity`
- *
  * @author Lucas Terra
  * @param dataRepository repository from DataEntity
  * @property update method to update a `DataEntity`
@@ -17,22 +15,13 @@ import the.coding.force.exploring_kotlin_coroutines.repository.DataRepository
 class UpdateDataService(
     private val dataRepository: DataRepository
 ) {
-    // logger to register the status of method update
     private val logger = KotlinLogging.logger { }
 
     /**
-     * received a `UpdateDataDto` from controller `update`
-     * and try to find the data to update it with the new information,
-     * if the data exists it will be updated with UpdateDataDto status info,
-     * case the data does not exist an exception `DataNotFoundException` will be thrown.
-     * The `logger` will register the status of update operation
-     *
      * @author Adriano Santos
      * @param dto is a data transfer objet from UpdateDataDto received from controller update
-     * @return `Unit`
      * @throws DataNotFoundException when the data with `ID` inside UpdateDataDto was not found this exception is thrown
      * @see UpdateDataDto
-     * @see logger
      */
     fun update(dto: UpdateDataDto) {
         dataRepository.findById(dto.id)


### PR DESCRIPTION
- Adição do javadoc para os serviços de CRUD <b>com</b> coroutine 
#22 (T1) [view commit](https://github.com/the-coding-force/exploring-kotlin-coroutines__backend__spring-kotlin__poc/pull/25/commits/551713c7457b9798ece953ea55b91d9262a2ddaf)

- Adição do javadoc para os serviços de CRUD <b>sem</b> coroutine 
#22 (T2) [view commit](https://github.com/the-coding-force/exploring-kotlin-coroutines__backend__spring-kotlin__poc/pull/25/commits/d45ff1c16295ca002481256dd2e4324f1c91db03)

- Adição do swagger para os controladores <b>com</b> coroutine 
#22 (T3) [view commit](https://github.com/the-coding-force/exploring-kotlin-coroutines__backend__spring-kotlin__poc/pull/25/commits/ea7defca287fbaab4c081a4c8f694546c0775be5)

- Adição do swagger para os controladores <b>sem</b> coroutine 
#22 (T4) [view commit](https://github.com/the-coding-force/exploring-kotlin-coroutines__backend__spring-kotlin__poc/pull/25/commits/c77b8ce135cc2663dbe2ab033dd4979f1d7aa859)

- Adição do swagger para os controladores referentes ao teste de carga (coroutine e sem coroutine) 
#22 (T5) [view commit](https://github.com/the-coding-force/exploring-kotlin-coroutines__backend__spring-kotlin__poc/pull/25/commits/6fd70eb709ce6dc60d54a42019be58b98846d630)

- Adição do swagger para as classes de dados como DTO's , requests e responses #22 (T6) [view commit](https://github.com/the-coding-force/exploring-kotlin-coroutines__backend__spring-kotlin__poc/pull/25/commits/a538f44441da734e7eb396ea0738d05dec63b364)