### PR TITLE
integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutineTestVersion")
+    testImplementation("org.awaitility:awaitility:4.2.0")
     testImplementation 'com.h2database:h2'
 
 

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/BulkCreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/BulkCreateControllerCoroutine.kt
@@ -34,6 +34,40 @@ class BulkCreateControllerCoroutine(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),
         ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                                "possibleErrors": [
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Cannot deserialize value of type `the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum` from String \"??\": not one of the values accepted for Enum class: [DELETED, COMPLETED, TODO]",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/coroutine/bulk/create"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Unrecognized token '??': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/coroutine/bulk/create"
+                                    }
+                                ]
+                            }"""
+                        ),
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
             responseCode = "500",
             description = "internal server error",
             content = [
@@ -48,7 +82,7 @@ class BulkCreateControllerCoroutine(
                             "error": "Internal Server Error",
                             "message": "Unexpected error occurred.",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exceṕtion", 
-                            "path": "/api/coroutine/create"
+                            "path": "/api/coroutine/bulk/create"
                            }"""
                         )
                     ]

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutine.kt
@@ -31,6 +31,40 @@ class CreateControllerCoroutine(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),
         ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                                "possibleErrors": [
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Cannot deserialize value of type `the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum` from String \"??\": not one of the values accepted for Enum class: [DELETED, COMPLETED, TODO]",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/coroutine/create"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Unrecognized token '??': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/coroutine/create"
+                                    }
+                                ]
+                            }"""
+                        ),
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
             responseCode = "500",
             description = "internal server error",
             content = [

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutine.kt
@@ -50,7 +50,50 @@ class DeleteControllerCoroutine(
                     ]
                 )
             ]
-        )
+        ),
+        ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 400,
+                            "error": "BAD_REQUEST",
+                            "message": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"??\"",
+                            "exceptionClass": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException", 
+                            "path": "/api/coroutine/delete/HelloWorld"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "path": "/api/coroutine/delete/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
     )
     @DeleteMapping("delete/{id}")
     suspend fun delete(

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutine.kt
@@ -45,13 +45,56 @@ class ReadControllerCoroutine(
                             "error": "NOT_FOUND",
                             "message": "Data with ID x was not found to retrieve it",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                            "path": "/api/coroutine/delete/10"
+                            "path": "/api/coroutine/read/10"
                            }"""
                         )
                     ]
                 )
             ]
-        )
+        ),
+        ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 400,
+                            "error": "BAD_REQUEST",
+                            "message": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"??\"",
+                            "exceptionClass": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException", 
+                            "path": "/api/coroutine/read/HelloWorld"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "path": "/api/coroutine/read/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
     )
     @GetMapping("read/{id}")
     suspend fun read(

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutine.kt
@@ -48,13 +48,76 @@ class UpdateControllerCoroutine(
                             "error": "NOT_FOUND",
                             "message": "Data with ID x was not found for update",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                            "path": "/api/coroutine/delete/10"
+                            "path": "/api/coroutine/update/10"
                            }"""
                         )
                     ]
                 )
             ]
-        )
+        ),
+        ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                                "possibleErrors": [
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Cannot deserialize value of type `the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum` from String \"??\": not one of the values accepted for Enum class: [DELETED, COMPLETED, TODO]",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/coroutine/update/10"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Unrecognized token '??': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/coroutine/update/10"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"??\"",
+                                        "exceptionClass": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException", 
+                                        "path": "/api/coroutine/update/HelloWorld"
+                                    }
+                                ]
+                            }"""
+                        )
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "path": "/api/coroutine/update/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
     )
     @PutMapping("update/{id}")
     suspend fun update(

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/BulkCreateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/BulkCreateController.kt
@@ -34,6 +34,40 @@ class BulkCreateController(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),
         ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                                "possibleErrors": [
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Cannot deserialize value of type `the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum` from String \"??\": not one of the values accepted for Enum class: [DELETED, COMPLETED, TODO]",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/bulk/create"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Unrecognized token '??': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/bulk/create"
+                                    }
+                                ]
+                            }"""
+                        ),
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
             responseCode = "500",
             description = "internal server error",
             content = [
@@ -48,7 +82,7 @@ class BulkCreateController(
                             "error": "Internal Server Error",
                             "message": "Unexpected error occurred.",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exceṕtion", 
-                            "path": "/api/coroutine/create"
+                            "path": "/api/bulk/create"
                            }"""
                         )
                     ]

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateController.kt
@@ -31,6 +31,40 @@ class CreateController(
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "success"),
         ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                                "possibleErrors": [
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Cannot deserialize value of type `the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum` from String \"??\": not one of the values accepted for Enum class: [DELETED, COMPLETED, TODO]",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/create"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Unrecognized token '??': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/create"
+                                    }
+                                ]
+                            }"""
+                        ),
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
             responseCode = "500",
             description = "internal server error",
             content = [
@@ -44,14 +78,13 @@ class CreateController(
                             "status": 500,
                             "error": "Internal Server Error",
                             "message": "Unexpected error occurred.",
-                            "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.Exception", 
-                            "path": "/api/coroutine/create"
+                            "path": "/api/create"
                            }"""
                         )
                     ]
                 )
             ]
-        )
+        ),
     )
     @PostMapping("/create")
     fun create(

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteController.kt
@@ -43,13 +43,56 @@ class DeleteController(
                             "error": "NOT_FOUND",
                             "message": "Data with ID x was not found for deletion",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                            "path": "/api/coroutine/delete/10"
+                            "path": "/api/delete/10"
                            }"""
                         )
                     ]
                 )
             ]
-        )
+        ),
+        ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 400,
+                            "error": "BAD_REQUEST",
+                            "message": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"??\"",
+                            "exceptionClass": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException", 
+                            "path": "/api/delete/HelloWorld"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "path": "/api/delete/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
     )
     @DeleteMapping("/delete/{id}")
     fun delete(
@@ -58,7 +101,6 @@ class DeleteController(
             description = "Unique identifier of the data to delete in the database",
             required = true,
             example = "10",
-            schema = Schema(type = "long", format = "int64", minimum = "1")
         )
         @PathVariable("id") dataId: Long
     ): ResponseEntity<Unit> {

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadController.kt
@@ -44,13 +44,56 @@ class ReadController(
                             "error": "NOT_FOUND",
                             "message": "Data with ID x was not found to retrieve it",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                            "path": "/api/coroutine/delete/10"
+                            "path": "/api/read/10"
                            }"""
                         )
                     ]
                 )
             ]
-        )
+        ),
+        ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                            "status": 400,
+                            "error": "BAD_REQUEST",
+                            "message": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"??\"",
+                            "exceptionClass": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException", 
+                            "path": "/api/read/HelloWorld"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "path": "/api/read/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
     )
     @GetMapping("/read/{id}")
     fun read(
@@ -59,7 +102,6 @@ class ReadController(
             description = "Unique identifier of the data to get in the database",
             required = true,
             example = "10",
-            schema = Schema(type = "long", format = "int64", minimum = "1"),
         )
         @PathVariable("id") dataId: Long
     ): ResponseEntity<ReadDataResponse> {

--- a/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateController.kt
+++ b/src/main/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateController.kt
@@ -47,13 +47,76 @@ class UpdateController(
                             "error": "NOT_FOUND",
                             "message": "Data with ID x was not found for update",
                             "exceptionClass": "the.coding.force.exploring_kotlin_coroutines.controller.coroutine.DataNotFoundException", 
-                            "path": "/api/coroutine/delete/10"
+                            "path": "/api/update/10"
                            }"""
                         )
                     ]
                 )
             ]
-        )
+        ),
+        ApiResponse(
+            responseCode = "400",
+            description = "bad request",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                                "possibleErrors": [
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Cannot deserialize value of type `the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum` from String \"??\": not one of the values accepted for Enum class: [DELETED, COMPLETED, TODO]",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/update/10"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-22T10:13:33.072654006-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "JSON parse error: Unrecognized token '??': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')",
+                                        "exceptionClass": "org.springframework.http.converter.HttpMessageNotReadableException",
+                                        "path": "/api/update/10"
+                                    },
+                                    {
+                                        "timestamp": "2024-12-11T13:19:14.083776445-03:00",
+                                        "status": 400,
+                                        "error": "BAD_REQUEST",
+                                        "message": "Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"??\"",
+                                        "exceptionClass": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException", 
+                                        "path": "/api/update/HelloWorld"
+                                    }
+                                ]
+                            }"""
+                        )
+                    ]
+                )
+            ]
+        ),
+        ApiResponse(
+            responseCode = "500",
+            description = "internal server error",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ResponseError::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{
+                            "timestamp": "2023-12-06T12:34:56",
+                            "status": 500,
+                            "error": "Internal Server Error",
+                            "message": "Unexpected error occurred.",
+                            "path": "/api/update/10"
+                           }"""
+                        )
+                    ]
+                )
+            ]
+        ),
     )
     @PutMapping("/update/{id}")
     fun update(
@@ -62,7 +125,6 @@ class UpdateController(
             description = "Unique identifier of the data to update in the database",
             required = true,
             example = "10",
-            schema = Schema(type = "long", format = "int64", minimum = "1"),
         )
         @PathVariable("id") dataId: Long,
 

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
@@ -1,16 +1,13 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
@@ -49,18 +46,13 @@ class CreateControllerCoroutineTest : IntegrationTests() {
         val incorrectData = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             post("/api/coroutine/create")
                 .content(incorrectData)
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(objError)
     }
 
     @Test
@@ -69,32 +61,12 @@ class CreateControllerCoroutineTest : IntegrationTests() {
         val entity = DataEntity(status = "HelloWorld")
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             post("/api/coroutine/create")
                 .content(objectMapper.writeValueAsString(entity))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(objError)
     }
-
-    private fun assertObjError(objError: ResponseError) {
-        println(objError)
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(400)
-        assertThat(objError.error).isEqualTo("BAD_REQUEST")
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo("org.springframework.http.converter.HttpMessageNotReadableException")
-        assertThat(objError.path).isEqualTo("/api/coroutine/create")
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
@@ -1,19 +1,22 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.assertj.core.api.Assertions.assertThat
-import org.awaitility.Awaitility
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
-import java.time.Duration
 
 class CreateControllerCoroutineTest : IntegrationTests() {
     @Test
-    fun `should create a entity successfully - controller with coroutine`() {
+    fun `should create a entity successfully`() {
         // Arrange
         val entity = DataEntity(
             status = DataStatusEnum.TODO.name
@@ -26,16 +29,71 @@ class CreateControllerCoroutineTest : IntegrationTests() {
                 .content(objectMapper.writeValueAsString(entity))
                 .accept(APPLICATION_JSON)
         )
-            .andExpect(status().isOk)
-
-        Awaitility.await()
-            .atMost(Duration.ofSeconds(10))
-            .untilAsserted {
-                val entityCreated = repository.findAll().first()
-
-                // Assert
-                assertThat(entityCreated.id).isNotNull()
-                assertThat(entityCreated.status).isEqualTo(DataStatusEnum.TODO.name)
+            .andExpect(request().asyncStarted())
+            .andReturn()
+            .also {
+                mockMvc.perform(asyncDispatch(it))
+                    .andExpect(status().isOk)
             }
+
+        val entityCreated = repository.findAll().first()
+
+        // Assert
+        assertThat(entityCreated.id).isNotNull()
+        assertThat(entityCreated.status).isEqualTo(DataStatusEnum.TODO.name)
     }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when requestBody was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            post("/api/coroutine/create")
+                .content(incorrectData)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(objError)
+    }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when some field on requestBody was wrote incorrectly`() {
+        // Arrange
+        val entity = DataEntity(status = "HelloWorld")
+
+        // Action
+        val result = mockMvc.perform(
+            post("/api/coroutine/create")
+                .content(objectMapper.writeValueAsString(entity))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(objError)
+    }
+
+    private fun assertObjError(objError: ResponseError) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(400)
+        assertThat(objError.error).isEqualTo("BAD_REQUEST")
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo("org.springframework.http.converter.HttpMessageNotReadableException")
+        assertThat(objError.path).isEqualTo("/api/coroutine/create")
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
@@ -84,6 +84,7 @@ class CreateControllerCoroutineTest : IntegrationTests() {
     }
 
     private fun assertObjError(objError: ResponseError) {
+        println(objError)
         assertThat(objError.timestamp).isNotNull()
         assertThat(objError.status).isEqualTo(400)
         assertThat(objError.error).isEqualTo("BAD_REQUEST")

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/CreateControllerCoroutineTest.kt
@@ -1,0 +1,41 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+import java.time.Duration
+
+class CreateControllerCoroutineTest : IntegrationTests() {
+    @Test
+    fun `should create a entity successfully - controller with coroutine`() {
+        // Arrange
+        val entity = DataEntity(
+            status = DataStatusEnum.TODO.name
+        )
+
+        // Action
+        mockMvc.perform(
+            post("/api/coroutine/create")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted {
+                val entityCreated = repository.findAll().first()
+
+                // Assert
+                assertThat(entityCreated.id).isNotNull()
+                assertThat(entityCreated.status).isEqualTo(DataStatusEnum.TODO.name)
+            }
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutineTest.kt
@@ -1,0 +1,37 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+import java.time.Duration
+
+class DeleteControllerCoroutineTest : IntegrationTests() {
+    @Test
+    fun `should delete a entity successfully - controller with coroutine`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+        println("entity: $entity")
+
+        // Action
+        mockMvc.perform(
+            delete("/api/coroutine/delete/{id}", entity.id)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted {
+                val entityDeleted = repository.findById(entity.id!!)
+
+                // Assert
+                assertThat(entityDeleted).isEmpty
+            }
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutineTest.kt
@@ -3,13 +3,11 @@ package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
@@ -44,7 +42,7 @@ class DeleteControllerCoroutineTest : IntegrationTests() {
         val nonExistingId = 1000L
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             delete("/api/coroutine/delete/{id}", nonExistingId)
                 .accept(APPLICATION_JSON)
         )
@@ -54,16 +52,6 @@ class DeleteControllerCoroutineTest : IntegrationTests() {
                 mockMvc.perform(asyncDispatch(it))
                     .andExpect(status().isNotFound)
             }
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            404,
-            "NOT_FOUND",
-            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
-            "/api/coroutine/delete/$nonExistingId"
-        )
     }
 
     @Test
@@ -72,41 +60,10 @@ class DeleteControllerCoroutineTest : IntegrationTests() {
         val incorrectData = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             delete("/api/coroutine/delete/{id}", incorrectData)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
-            "/api/coroutine/delete/$incorrectData"
-        )
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
-
-    private fun assertObjError(
-        objError: ResponseError,
-        status: Int,
-        error: String,
-        exceptionClass: String,
-        path: String
-    ) {
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(status)
-        assertThat(objError.error).isEqualTo(error)
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
-        assertThat(objError.path).isEqualTo(path)
     }
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/DeleteControllerCoroutineTest.kt
@@ -1,19 +1,21 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
 import org.assertj.core.api.Assertions.assertThat
-import org.awaitility.Awaitility
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
-import java.time.Duration
 
 class DeleteControllerCoroutineTest : IntegrationTests() {
     @Test
-    fun `should delete a entity successfully - controller with coroutine`() {
+    fun `should delete a entity successfully`() {
         // Arrange
         val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
         println("entity: $entity")
@@ -23,15 +25,88 @@ class DeleteControllerCoroutineTest : IntegrationTests() {
             delete("/api/coroutine/delete/{id}", entity.id)
                 .accept(APPLICATION_JSON)
         )
-            .andExpect(status().isOk)
-
-        Awaitility.await()
-            .atMost(Duration.ofSeconds(10))
-            .untilAsserted {
-                val entityDeleted = repository.findById(entity.id!!)
-
-                // Assert
-                assertThat(entityDeleted).isEmpty
+            .andExpect(request().asyncStarted())
+            .andReturn()
+            .also {
+                mockMvc.perform(asyncDispatch(it))
+                    .andExpect(status().isOk)
             }
+
+        val entityDeleted = repository.findById(entity.id!!)
+
+        // Assert
+        assertThat(entityDeleted).isEmpty
+    }
+
+    @Test
+    fun `should throw a DataNotFoundException when ID was not found`() {
+        // Arrange
+        val nonExistingId = 1000L
+
+        // Action
+        val result = mockMvc.perform(
+            delete("/api/coroutine/delete/{id}", nonExistingId)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(request().asyncStarted())
+            .andReturn()
+            .also {
+                mockMvc.perform(asyncDispatch(it))
+                    .andExpect(status().isNotFound)
+            }
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            404,
+            "NOT_FOUND",
+            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
+            "/api/coroutine/delete/$nonExistingId"
+        )
+    }
+
+    @Test
+    fun `should throw a MethodArgumentTypeMismatchException when ID was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            delete("/api/coroutine/delete/{id}", incorrectData)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
+            "/api/coroutine/delete/$incorrectData"
+        )
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
+
+    private fun assertObjError(
+        objError: ResponseError,
+        status: Int,
+        error: String,
+        exceptionClass: String,
+        path: String
+    ) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(status)
+        assertThat(objError.error).isEqualTo(error)
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
+        assertThat(objError.path).isEqualTo(path)
     }
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutineTest.kt
@@ -3,13 +3,11 @@ package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
@@ -44,7 +42,7 @@ class ReadControllerCoroutineTest : IntegrationTests() {
         val nonExistingId = 1000L
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             get("/api/coroutine/read/{id}", nonExistingId)
                 .accept(APPLICATION_JSON)
         )
@@ -54,17 +52,6 @@ class ReadControllerCoroutineTest : IntegrationTests() {
                 mockMvc.perform(asyncDispatch(it))
                     .andExpect(status().isNotFound)
             }
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            404,
-            "NOT_FOUND",
-            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
-            "/api/coroutine/read/$nonExistingId"
-        )
-        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found to retrieve it")
     }
 
     @Test
@@ -73,41 +60,10 @@ class ReadControllerCoroutineTest : IntegrationTests() {
         val incorrectData = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             get("/api/coroutine/read/{id}", incorrectData)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
-            "/api/coroutine/read/$incorrectData"
-        )
     }
-
-    private fun assertObjError(
-        objError: ResponseError,
-        status: Int,
-        error: String,
-        exceptionClass: String,
-        path: String
-    ) {
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(status)
-        assertThat(objError.error).isEqualTo(error)
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
-        assertThat(objError.path).isEqualTo(path)
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutineTest.kt
@@ -1,19 +1,21 @@
 package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
 
 import org.assertj.core.api.Assertions.assertThat
-import org.awaitility.Awaitility
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
-import java.time.Duration
 
 class ReadControllerCoroutineTest : IntegrationTests() {
     @Test
-    fun `should get a entity successfully - controller with coroutine`() {
+    fun `should get a entity successfully`() {
         // Arrange
         val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
         println("entity: $entity")
@@ -23,15 +25,89 @@ class ReadControllerCoroutineTest : IntegrationTests() {
             get("/api/coroutine/read/{id}", entity.id)
                 .accept(APPLICATION_JSON)
         )
-            .andExpect(status().isOk)
-
-        Awaitility.await()
-            .atMost(Duration.ofSeconds(10))
-            .untilAsserted {
-                val entityCreated = repository.findById(entity.id!!)
-                // Assert
-                assertThat(entityCreated.get().id).isEqualTo(entity.id)
-                assertThat(entityCreated.get().status).isEqualTo(entity.status)
+            .andExpect(request().asyncStarted())
+            .andReturn()
+            .also {
+                mockMvc.perform(asyncDispatch(it))
+                    .andExpect(status().isOk)
             }
+
+        val entityCreated = repository.findById(entity.id!!)
+        // Assert
+        assertThat(entityCreated.get().id).isEqualTo(entity.id)
+        assertThat(entityCreated.get().status).isEqualTo(entity.status)
     }
+
+    @Test
+    fun `should throw a DataNotFoundException when ID was not found to get`() {
+        // Arrange
+        val nonExistingId = 1000L
+
+        // Action
+        val result = mockMvc.perform(
+            get("/api/coroutine/read/{id}", nonExistingId)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(request().asyncStarted())
+            .andReturn()
+            .also {
+                mockMvc.perform(asyncDispatch(it))
+                    .andExpect(status().isNotFound)
+            }
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            404,
+            "NOT_FOUND",
+            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
+            "/api/coroutine/read/$nonExistingId"
+        )
+        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found to retrieve it")
+    }
+
+    @Test
+    fun `should throw a MethodArgumentTypeMismatchException when ID was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            get("/api/coroutine/read/{id}", incorrectData)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
+            "/api/coroutine/read/$incorrectData"
+        )
+    }
+
+    private fun assertObjError(
+        objError: ResponseError,
+        status: Int,
+        error: String,
+        exceptionClass: String,
+        path: String
+    ) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(status)
+        assertThat(objError.error).isEqualTo(error)
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
+        assertThat(objError.path).isEqualTo(path)
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/ReadControllerCoroutineTest.kt
@@ -1,0 +1,37 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+import java.time.Duration
+
+class ReadControllerCoroutineTest : IntegrationTests() {
+    @Test
+    fun `should get a entity successfully - controller with coroutine`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+        println("entity: $entity")
+
+        // Action
+        mockMvc.perform(
+            get("/api/coroutine/read/{id}", entity.id)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted {
+                val entityCreated = repository.findById(entity.id!!)
+                // Assert
+                assertThat(entityCreated.get().id).isEqualTo(entity.id)
+                assertThat(entityCreated.get().status).isEqualTo(entity.status)
+            }
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutineTest.kt
@@ -4,9 +4,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
@@ -48,4 +52,114 @@ class UpdateControllerCoroutineTest : IntegrationTests() {
         assertThat(entityAfter!!.id).isEqualTo(entityUpdates.id)
         assertThat(entityAfter.status).isEqualTo(entityUpdates.status)
     }
+
+    @Test
+    fun `should throw a DataNotFoundException when ID was not found to update`() {
+        // Arrange
+        val nonExistingId = 1000L
+        val entity = DataEntity(id = nonExistingId, status = DataStatusEnum.COMPLETED.name)
+
+        // Action
+        val result = mockMvc.perform(
+            put("/api/coroutine/update/{id}", nonExistingId)
+                .content(objectMapper.writeValueAsString(entity))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(request().asyncStarted())
+            .andReturn()
+            .also {
+                mockMvc.perform(asyncDispatch(it))
+                    .andExpect(status().isNotFound)
+            }
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            404,
+            "NOT_FOUND",
+            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
+            "/api/coroutine/update/$nonExistingId"
+        )
+        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found for update")
+    }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when requestBody was wrote incorrectly`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+
+        val entityUpdated = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            put("/api/coroutine/update/{id}", entity.id)
+                .content(objectMapper.writeValueAsString(entityUpdated))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.http.converter.HttpMessageNotReadableException",
+            "/api/coroutine/update/${entity.id}"
+        )
+    }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when some field on requestBody was wrote incorrectly`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+
+        val entityUpdated = DataEntity(
+            status = "HelloWorld"
+        )
+
+        // Action
+        val result = mockMvc.perform(
+            put("/api/coroutine/update/{id}", entity.id)
+                .content(objectMapper.writeValueAsString(entityUpdated))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.http.converter.HttpMessageNotReadableException",
+            "/api/coroutine/update/${entity.id}"
+        )
+    }
+
+    private fun assertObjError(
+        objError: ResponseError,
+        status: Int,
+        error: String,
+        exceptionClass: String,
+        path: String
+    ) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(status)
+        assertThat(objError.error).isEqualTo(error)
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
+        assertThat(objError.path).isEqualTo(path)
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutineTest.kt
@@ -4,13 +4,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
@@ -60,7 +58,7 @@ class UpdateControllerCoroutineTest : IntegrationTests() {
         val entity = DataEntity(id = nonExistingId, status = DataStatusEnum.COMPLETED.name)
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             put("/api/coroutine/update/{id}", nonExistingId)
                 .content(objectMapper.writeValueAsString(entity))
                 .contentType(APPLICATION_JSON)
@@ -72,17 +70,6 @@ class UpdateControllerCoroutineTest : IntegrationTests() {
                 mockMvc.perform(asyncDispatch(it))
                     .andExpect(status().isNotFound)
             }
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            404,
-            "NOT_FOUND",
-            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
-            "/api/coroutine/update/$nonExistingId"
-        )
-        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found for update")
     }
 
     @Test
@@ -93,24 +80,13 @@ class UpdateControllerCoroutineTest : IntegrationTests() {
         val entityUpdated = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             put("/api/coroutine/update/{id}", entity.id)
                 .content(objectMapper.writeValueAsString(entityUpdated))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.http.converter.HttpMessageNotReadableException",
-            "/api/coroutine/update/${entity.id}"
-        )
     }
 
     @Test
@@ -123,43 +99,12 @@ class UpdateControllerCoroutineTest : IntegrationTests() {
         )
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             put("/api/coroutine/update/{id}", entity.id)
                 .content(objectMapper.writeValueAsString(entityUpdated))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.http.converter.HttpMessageNotReadableException",
-            "/api/coroutine/update/${entity.id}"
-        )
     }
-
-    private fun assertObjError(
-        objError: ResponseError,
-        status: Int,
-        error: String,
-        exceptionClass: String,
-        path: String
-    ) {
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(status)
-        assertThat(objError.error).isEqualTo(error)
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
-        assertThat(objError.path).isEqualTo(path)
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutineTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/coroutine/UpdateControllerCoroutineTest.kt
@@ -1,0 +1,51 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.coroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
+import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
+import the.coding.force.exploring_kotlin_coroutines.request.CreateDataRequest
+
+class UpdateControllerCoroutineTest : IntegrationTests() {
+    @Test
+    fun `Should update a task with success - Controller with coroutine`() {
+        // Arrange
+        val createDataRequest = CreateDataRequest(
+            status = DataStatusEnum.TODO
+        )
+
+        val entityBefore = repository.save(
+            createDataRequest.toDto().toEntity()
+        )
+
+        println("entityBefore: $entityBefore")
+
+        val entityUpdates = DataEntity(
+            id = entityBefore.id,
+            status = DataStatusEnum.COMPLETED.name,
+        )
+
+        // Action
+        mockMvc.perform(
+            put("/api/coroutine/update/{id}", entityBefore.id)
+                .content(objectMapper.writeValueAsString(entityUpdates))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        Thread.sleep(1000) // required to pass the test
+        val entityAfter = repository.findByIdOrNull(entityUpdates.id!!)
+
+        // Assert
+        assertThat(entityAfter!!.id).isEqualTo(entityUpdates.id)
+        assertThat(entityAfter.status).isEqualTo(entityUpdates.status)
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateControllerTest.kt
@@ -1,0 +1,35 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+
+class CreateControllerTest : IntegrationTests() {
+    @Test
+    fun `should create a entity successfully - controller without coroutine`() {
+        // Arrange
+        val entity = DataEntity(
+            status = DataStatusEnum.TODO.name
+        )
+
+        // Action
+        mockMvc.perform(
+            post("/api/create")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(entity))
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        // Assert
+        val entityCreated = repository.findAll().first()
+
+        assertThat(entityCreated.id).isNotNull()
+        assertThat(entityCreated.status).isEqualTo(DataStatusEnum.TODO.name)
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateControllerTest.kt
@@ -3,15 +3,17 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
 class CreateControllerTest : IntegrationTests() {
     @Test
-    fun `should create a entity successfully - controller without coroutine`() {
+    fun `should create a entity successfully`() {
         // Arrange
         val entity = DataEntity(
             status = DataStatusEnum.TODO.name
@@ -32,4 +34,58 @@ class CreateControllerTest : IntegrationTests() {
         assertThat(entityCreated.id).isNotNull()
         assertThat(entityCreated.status).isEqualTo(DataStatusEnum.TODO.name)
     }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when requestBody was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = "helloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            post("/api/create")
+                .content(incorrectData)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(objError)
+    }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when some field on requestBody was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = DataEntity(status = "helloWorld")
+
+        // Action
+        val result = mockMvc.perform(
+            post("/api/create")
+                .content(objectMapper.writeValueAsString(incorrectData))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(objError)
+    }
+
+    private fun assertObjError(objError: ResponseError) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(400)
+        assertThat(objError.error).isEqualTo("BAD_REQUEST")
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo("org.springframework.http.converter.HttpMessageNotReadableException")
+        assertThat(objError.path).isEqualTo("/api/create")
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/CreateControllerTest.kt
@@ -3,11 +3,9 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
@@ -41,18 +39,13 @@ class CreateControllerTest : IntegrationTests() {
         val incorrectData = "helloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             post("/api/create")
                 .content(incorrectData)
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(objError)
     }
 
     @Test
@@ -61,31 +54,12 @@ class CreateControllerTest : IntegrationTests() {
         val incorrectData = DataEntity(status = "helloWorld")
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             post("/api/create")
                 .content(objectMapper.writeValueAsString(incorrectData))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(objError)
     }
-
-    private fun assertObjError(objError: ResponseError) {
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(400)
-        assertThat(objError.error).isEqualTo("BAD_REQUEST")
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo("org.springframework.http.converter.HttpMessageNotReadableException")
-        assertThat(objError.path).isEqualTo("/api/create")
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
@@ -3,15 +3,17 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
 class DeleteControllerTest : IntegrationTests() {
     @Test
-    fun `should delete a entity successfully - controller without coroutine`() {
+    fun `should delete a entity successfully`() {
         // Arrange
         val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
         println("entity: $entity")
@@ -22,10 +24,79 @@ class DeleteControllerTest : IntegrationTests() {
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isOk)
+            .andReturn()
 
         val entityDeleted = repository.findById(entity.id!!)
-
         // Assert
         assertThat(entityDeleted).isEmpty
     }
+
+    @Test
+    fun `should throw a DataNotFoundException when ID was not found to delete`() {
+        // Arrange
+        val nonExistingId = 1000L
+
+        // Action
+        val result = mockMvc.perform(
+            delete("/api/delete/{id}", nonExistingId)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isNotFound)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            404,
+            "NOT_FOUND",
+            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
+            "/api/delete/$nonExistingId"
+        )
+        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found for deletion")
+    }
+
+    @Test
+    fun `should throw a MethodArgumentTypeMismatchException when ID was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            delete("/api/delete/{id}", incorrectData)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
+            "/api/delete/$incorrectData"
+        )
+    }
+
+    private fun assertObjError(
+        objError: ResponseError,
+        status: Int,
+        error: String,
+        exceptionClass: String,
+        path: String
+    ) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(status)
+        assertThat(objError.error).isEqualTo(error)
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
+        assertThat(objError.path).isEqualTo(path)
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
@@ -87,6 +87,7 @@ class DeleteControllerTest : IntegrationTests() {
         exceptionClass: String,
         path: String
     ) {
+        println(objError)
         assertThat(objError.timestamp).isNotNull()
         assertThat(objError.status).isEqualTo(status)
         assertThat(objError.error).isEqualTo(error)

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
@@ -1,0 +1,31 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+
+class DeleteControllerTest : IntegrationTests() {
+    @Test
+    fun `should delete a entity successfully - controller without coroutine`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+        println("entity: $entity")
+
+        // Action
+        mockMvc.perform(
+            delete("/api/delete/{id}", entity.id)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        val entityDeleted = repository.findById(entity.id!!)
+
+        // Assert
+        assertThat(entityDeleted).isEmpty
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/DeleteControllerTest.kt
@@ -3,11 +3,9 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
@@ -37,23 +35,11 @@ class DeleteControllerTest : IntegrationTests() {
         val nonExistingId = 1000L
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             delete("/api/delete/{id}", nonExistingId)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isNotFound)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            404,
-            "NOT_FOUND",
-            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
-            "/api/delete/$nonExistingId"
-        )
-        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found for deletion")
     }
 
     @Test
@@ -62,42 +48,10 @@ class DeleteControllerTest : IntegrationTests() {
         val incorrectData = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             delete("/api/delete/{id}", incorrectData)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
-            "/api/delete/$incorrectData"
-        )
     }
-
-    private fun assertObjError(
-        objError: ResponseError,
-        status: Int,
-        error: String,
-        exceptionClass: String,
-        path: String
-    ) {
-        println(objError)
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(status)
-        assertThat(objError.error).isEqualTo(error)
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
-        assertThat(objError.path).isEqualTo(path)
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadControllerTest.kt
@@ -3,16 +3,18 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
 class ReadControllerTest : IntegrationTests() {
 
     @Test
-    fun `should get a entity successfully - controller without coroutine`() {
+    fun `should get a entity successfully`() {
         // Arrange
         val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
         println("entity: $entity")
@@ -29,4 +31,73 @@ class ReadControllerTest : IntegrationTests() {
         assertThat(entityCreated.get().id).isEqualTo(entity.id)
         assertThat(entityCreated.get().status).isEqualTo(entity.status)
     }
+
+    @Test
+    fun `should throw a DataNotFoundException when ID was not found to get`() {
+        // Arrange
+        val nonExistingId = 1000L
+
+        // Action
+        val result = mockMvc.perform(
+            get("/api/read/{id}", nonExistingId)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isNotFound)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            404,
+            "NOT_FOUND",
+            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
+            "/api/read/$nonExistingId"
+        )
+        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found to retrieve it")
+    }
+
+    @Test
+    fun `should throw a MethodArgumentTypeMismatchException when ID was wrote incorrectly`() {
+        // Arrange
+        val incorrectData = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            get("/api/read/{id}", incorrectData)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
+            "/api/read/$incorrectData"
+        )
+    }
+
+    private fun assertObjError(
+        objError: ResponseError,
+        status: Int,
+        error: String,
+        exceptionClass: String,
+        path: String
+    ) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(status)
+        assertThat(objError.error).isEqualTo(error)
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
+        assertThat(objError.path).isEqualTo(path)
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadControllerTest.kt
@@ -3,11 +3,9 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 
@@ -38,23 +36,11 @@ class ReadControllerTest : IntegrationTests() {
         val nonExistingId = 1000L
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             get("/api/read/{id}", nonExistingId)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isNotFound)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            404,
-            "NOT_FOUND",
-            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
-            "/api/read/$nonExistingId"
-        )
-        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found to retrieve it")
     }
 
     @Test
@@ -63,41 +49,10 @@ class ReadControllerTest : IntegrationTests() {
         val incorrectData = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             get("/api/read/{id}", incorrectData)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
-            "/api/read/$incorrectData"
-        )
     }
-
-    private fun assertObjError(
-        objError: ResponseError,
-        status: Int,
-        error: String,
-        exceptionClass: String,
-        path: String
-    ) {
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(status)
-        assertThat(objError.error).isEqualTo(error)
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
-        assertThat(objError.path).isEqualTo(path)
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/ReadControllerTest.kt
@@ -1,0 +1,32 @@
+package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
+import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
+
+class ReadControllerTest : IntegrationTests() {
+
+    @Test
+    fun `should get a entity successfully - controller without coroutine`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+        println("entity: $entity")
+
+        // Action
+        mockMvc.perform(
+            get("/api/read/{id}", entity.id)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+
+        val entityCreated = repository.findById(entity.id!!)
+        // Assert
+        assertThat(entityCreated.get().id).isEqualTo(entity.id)
+        assertThat(entityCreated.get().status).isEqualTo(entity.status)
+    }
+}

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateControllerTest.kt
@@ -3,11 +3,9 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
-import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
-import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
@@ -56,25 +54,13 @@ class UpdateControllerTest : IntegrationTests() {
         val entity = DataEntity(id = nonExistingId, status = DataStatusEnum.COMPLETED.name)
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             put("/api/update/{id}", nonExistingId)
                 .content(objectMapper.writeValueAsString(entity))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isNotFound)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            404,
-            "NOT_FOUND",
-            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
-            "/api/update/$nonExistingId"
-        )
-        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found for update")
     }
 
     @Test
@@ -85,24 +71,13 @@ class UpdateControllerTest : IntegrationTests() {
         val entityUpdated = "HelloWorld"
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             put("/api/update/{id}", entity.id)
                 .content(objectMapper.writeValueAsString(entityUpdated))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.http.converter.HttpMessageNotReadableException",
-            "/api/update/${entity.id}"
-        )
     }
 
     @Test
@@ -115,43 +90,12 @@ class UpdateControllerTest : IntegrationTests() {
         )
 
         // Action
-        val result = mockMvc.perform(
+        mockMvc.perform(
             put("/api/update/{id}", entity.id)
                 .content(objectMapper.writeValueAsString(entityUpdated))
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
         )
             .andExpect(status().isBadRequest)
-            .andReturn()
-
-        val objError = getResponseErrorObj(result)
-        // Assert
-        assertObjError(
-            objError,
-            400,
-            "BAD_REQUEST",
-            "org.springframework.http.converter.HttpMessageNotReadableException",
-            "/api/update/${entity.id}"
-        )
     }
-
-    private fun assertObjError(
-        objError: ResponseError,
-        status: Int,
-        error: String,
-        exceptionClass: String,
-        path: String
-    ) {
-        assertThat(objError.timestamp).isNotNull()
-        assertThat(objError.status).isEqualTo(status)
-        assertThat(objError.error).isEqualTo(error)
-        assertThat(objError.message).isNotNull()
-        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
-        assertThat(objError.path).isEqualTo(path)
-    }
-
-    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
-        result.response.contentAsString,
-        ResponseError::class.java
-    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateControllerTest.kt
@@ -3,9 +3,11 @@ package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import the.coding.force.exploring_kotlin_coroutines.IntegrationTests
+import the.coding.force.exploring_kotlin_coroutines.controller.handler.ResponseError
 import the.coding.force.exploring_kotlin_coroutines.entities.DataEntity
 import the.coding.force.exploring_kotlin_coroutines.enums.DataStatusEnum
 import the.coding.force.exploring_kotlin_coroutines.mapper.toDto
@@ -13,9 +15,8 @@ import the.coding.force.exploring_kotlin_coroutines.mapper.toEntity
 import the.coding.force.exploring_kotlin_coroutines.request.CreateDataRequest
 
 class UpdateControllerTest : IntegrationTests() {
-
     @Test
-    fun `Should update a task with success - Controller without coroutine`() {
+    fun `Should update a task with success`() {
         // Arrange
         val createDataRequest = CreateDataRequest(
             status = DataStatusEnum.TODO
@@ -47,4 +48,110 @@ class UpdateControllerTest : IntegrationTests() {
         assertThat(entityAfter.id).isEqualTo(entityUpdates.id)
         assertThat(entityAfter.status).isEqualTo(entityUpdates.status)
     }
+
+    @Test
+    fun `should throw a DataNotFoundException when ID was not found to update`() {
+        // Arrange
+        val nonExistingId = 1000L
+        val entity = DataEntity(id = nonExistingId, status = DataStatusEnum.COMPLETED.name)
+
+        // Action
+        val result = mockMvc.perform(
+            put("/api/update/{id}", nonExistingId)
+                .content(objectMapper.writeValueAsString(entity))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isNotFound)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            404,
+            "NOT_FOUND",
+            "the.coding.force.exploring_kotlin_coroutines.exception.DataNotFoundException",
+            "/api/update/$nonExistingId"
+        )
+        assertThat(objError.message).isEqualTo("Data with ID $nonExistingId was not found for update")
+    }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when requestBody was wrote incorrectly`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+
+        val entityUpdated = "HelloWorld"
+
+        // Action
+        val result = mockMvc.perform(
+            put("/api/update/{id}", entity.id)
+                .content(objectMapper.writeValueAsString(entityUpdated))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.http.converter.HttpMessageNotReadableException",
+            "/api/update/${entity.id}"
+        )
+    }
+
+    @Test
+    fun `should throw a HttpMessageNotReadableException when some field on requestBody was wrote incorrectly`() {
+        // Arrange
+        val entity = repository.save(DataEntity(status = DataStatusEnum.TODO.name))
+
+        val entityUpdated = DataEntity(
+            status = "HelloWorld"
+        )
+
+        // Action
+        val result = mockMvc.perform(
+            put("/api/update/{id}", entity.id)
+                .content(objectMapper.writeValueAsString(entityUpdated))
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+
+        val objError = getResponseErrorObj(result)
+        // Assert
+        assertObjError(
+            objError,
+            400,
+            "BAD_REQUEST",
+            "org.springframework.http.converter.HttpMessageNotReadableException",
+            "/api/update/${entity.id}"
+        )
+    }
+
+    private fun assertObjError(
+        objError: ResponseError,
+        status: Int,
+        error: String,
+        exceptionClass: String,
+        path: String
+    ) {
+        assertThat(objError.timestamp).isNotNull()
+        assertThat(objError.status).isEqualTo(status)
+        assertThat(objError.error).isEqualTo(error)
+        assertThat(objError.message).isNotNull()
+        assertThat(objError.exceptionClass).isEqualTo(exceptionClass)
+        assertThat(objError.path).isEqualTo(path)
+    }
+
+    private fun getResponseErrorObj(result: MvcResult) = objectMapper.readValue(
+        result.response.contentAsString,
+        ResponseError::class.java
+    )
 }

--- a/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateControllerTest.kt
+++ b/src/test/kotlin/the/coding/force/exploring_kotlin_coroutines/controller/withoutCoroutine/UpdateControllerTest.kt
@@ -1,8 +1,7 @@
-package the.coding.force.exploring_kotlin_coroutines.controller
+package the.coding.force.exploring_kotlin_coroutines.controller.withoutCoroutine
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -46,41 +45,6 @@ class UpdateControllerTest : IntegrationTests() {
 
         // Assert
         assertThat(entityAfter.id).isEqualTo(entityUpdates.id)
-        assertThat(entityAfter.status).isEqualTo(entityUpdates.status)
-    }
-
-    @Test
-    fun `Should update a task with success - Controller with coroutine`() {
-        // Arrange
-        val createDataRequest = CreateDataRequest(
-            status = DataStatusEnum.TODO
-        )
-
-        val entityBefore = repository.save(
-            createDataRequest.toDto().toEntity()
-        )
-
-        println("entityBefore: $entityBefore")
-
-        val entityUpdates = DataEntity(
-            id = entityBefore.id,
-            status = DataStatusEnum.COMPLETED.name,
-        )
-
-        // Action
-        mockMvc.perform(
-            put("/api/coroutine/update/{id}", entityBefore.id)
-                .content(objectMapper.writeValueAsString(entityUpdates))
-                .contentType(APPLICATION_JSON)
-                .accept(APPLICATION_JSON)
-        )
-            .andExpect(status().isOk)
-
-        Thread.sleep(1000) // required to pass the test
-        val entityAfter = repository.findByIdOrNull(entityUpdates.id!!)
-
-        // Assert
-        assertThat(entityAfter!!.id).isEqualTo(entityUpdates.id)
         assertThat(entityAfter.status).isEqualTo(entityUpdates.status)
     }
 }


### PR DESCRIPTION
- Desenvolvimento de testes de integração para os cenários de CRUD sem exceptions (caminho feliz)
- remoção da biblioteca `Awaitiblity` para usar funções nativas do mockMvc para tratamento dos controladores assíncronos 
- Adição de 2 handlers para casos específicos de erros relacionados a tipos de dados inválidos para as requests, tais como `MethodArgumentTypeMismatchException` e `HttpMessageNotReadableException` 
- Adição de um handler genérico `Exception` para tratamento de quaisquer outros erros não previsíveis anteriormente.
- Documentação dos controladores atualizada para cobrir novos casos de erros